### PR TITLE
Add `dry_run` input option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,13 @@ inputs:
   verbose:
     description: "Print module and source location in logs."
     required: false
+  dry_run:
+    description:
+      "Do a `--dry-run`. Only applicable for the command `release`.
+      If the input `command` is left unspecified (and so both `release` and `release-pr` are ran),
+      only the `release` part will be ran with `--dry-run`.
+      Useful if you're only interested in whether or not a release (pr) would be created."
+    required: false
 outputs:
   # Useful for when https://github.com/release-plz/release-plz/issues/1029 is implemented.
   # For now, it just returns an array with `pr` in it.
@@ -81,6 +88,13 @@ runs:
             VERBOSE=("-v")
         else
             VERBOSE=()
+        fi
+
+        if [[ -n "${{ inputs.dry_run }}" ]]
+        then
+            DRY_RUN=("--dry-run")
+        else
+            DRY_RUN=()
         fi
 
         if [[ -n "${{ inputs.token }}" ]]
@@ -157,6 +171,7 @@ runs:
                 "${BACKEND[@]}"\
                 "${TOKEN[@]}"\
                 "${VERBOSE[@]}"\
+                "${DRY_RUN[@]}"\
                 -o json)
             echo "release_output: $release_output"
             releases=$(echo $release_output | jq -c .releases)


### PR DESCRIPTION
This is useful if you don't actually want to release, but you're just interested in whether or not a release would be created. Useful to gate a secondary job with an environment, without creating requests for each and every change.

Fixes #200