### PR TITLE
feat: improve compatibility with other runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,12 @@ inputs:
   verbose:
     description: "Print module and source location in logs."
     required: false
-  # Minimal git config is needed for release-plz to work. On non-github platforms like gitea or
-  # forgejo/act, you are needed to switch "git_config" off and to externally provide a valid git
-  # configuration yourself. You can e.g: use OleksiyRudenko/gha-git-credentials for this.
   git_config:
-    description: "GitHub only, configure git user/email from GITHUB_TOKEN"
+    description:
+      "Configure git user/email from GITHUB_TOKEN.
+      Minimal git config is needed for release-plz to work. On non-github platforms like Gitea or
+      Forgejo/Act, you are needed to switch `git_config` off and externally provide a valid git
+      configuration yourself. For example, you can use OleksiyRudenko/gha-git-credentials for this."
     default: true
     required: false
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,6 @@ runs:
             echo "-- Running release-plz release-pr --"
             release_pr_output=$(release-plz release-pr\
                 --git-token "${GITHUB_TOKEN}"\
-                --repo-url "https://github.com/${GITHUB_REPOSITORY}"\
                 "${CONFIG_PATH[@]}"\
                 "${ALT_REGISTRY[@]}"\
                 "${MANIFEST_PATH[@]}"\

--- a/action.yml
+++ b/action.yml
@@ -37,8 +37,9 @@ inputs:
   verbose:
     description: "Print module and source location in logs."
     required: false
-  # Minimal git config is needed for release-plz to work. If you switch this off on non-github
-  # platforms, you need to externally provide this configuration e.g: OleksiyRudenko/gha-git-credentials
+  # Minimal git config is needed for release-plz to work. On non-github platforms like gitea or
+  # forgejo/act, you are needed to switch "git_config" off and to externally provide a valid git
+  # configuration yourself. You can e.g: use OleksiyRudenko/gha-git-credentials for this.
   git_config:
     description: "GitHub only, configure git user/email from GITHUB_TOKEN"
     default: true

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
     required: false
   git_config:
     description:
-      "Configure git user/email from GITHUB_TOKEN.
+      "Configure git user/email automatically from GITHUB_TOKEN.
       Minimal git config is needed for release-plz to work. On non-github platforms like Gitea or
       Forgejo/Act, you are needed to switch `git_config` off and externally provide a valid git
       configuration yourself. For example, you can use OleksiyRudenko/gha-git-credentials for this."

--- a/action.yml
+++ b/action.yml
@@ -62,11 +62,11 @@ runs:
   using: "composite"
   steps:
     - name: Install binaries
-      uses: taiki-e/install-action@v2
+      uses: https://github.com/taiki-e/install-action@v2
       with:
         tool: cargo-semver-checks@0.43, release-plz@${{ inputs.version }}
     - name: Configure git user from GitHub token
-      uses: release-plz/git-config@59144859caf016f8b817a2ac9b051578729173c4
+      uses: https://github.com/release-plz/git-config@59144859caf016f8b817a2ac9b051578729173c4
     - name: Run release-plz
       id: release-plz
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     description: "Print module and source location in logs."
     required: false
   # Minimal git config is needed for release-plz to work. If you switch this off on non-github
-  # platforms, you are needed to externally provide this configuration e.g: OleksiyRudenko/gha-git-credentials
+  # platforms, you need to externally provide this configuration e.g: OleksiyRudenko/gha-git-credentials
   git_config:
     description: "GitHub only, configure git user/email from GITHUB_TOKEN"
     default: true

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,12 @@ inputs:
   verbose:
     description: "Print module and source location in logs."
     required: false
+  # Minimal git config is needed for release-plz to work. If you switch this off on non-github
+  # platforms, you are needed to externally provide this configuration e.g: OleksiyRudenko/gha-git-credentials
+  git_config:
+    description: "GitHub only, configure git user/email from GITHUB_TOKEN"
+    default: true
+    required: false
 outputs:
   # Useful for when https://github.com/release-plz/release-plz/issues/1029 is implemented.
   # For now, it just returns an array with `pr` in it.
@@ -66,6 +72,7 @@ runs:
       with:
         tool: cargo-semver-checks@0.43, release-plz@${{ inputs.version }}
     - name: Configure git user from GitHub token
+      if: ${{ inputs.git_config == 'true' }}
       uses: https://github.com/release-plz/git-config@59144859caf016f8b817a2ac9b051578729173c4
     - name: Run release-plz
       id: release-plz


### PR DESCRIPTION
using fully qualified actions improves compatibility with non-github runners like forgejo-runner and nektos/act

The gh tool might not be available on non-github runners. Make git-config optional, so that other means can be applied by the user.

remove arg --repo-url: repo-url can be automatically determined from the git repo.
To make it forge independent remove the repo-url argument completely